### PR TITLE
[PLAT-199] avd-manager step issues

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -79,7 +79,6 @@ workflows:
         title: Step Test
         inputs:
         - api_level: $EMU_VER
-        - tag: "default"
     - script:
         inputs:
         - content: |

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -79,6 +79,7 @@ workflows:
         title: Step Test
         inputs:
         - api_level: $EMU_VER
+        - tag: "default"
     - script:
         inputs:
         - content: |


### PR DESCRIPTION
- Added the `tag` input parameter to the tests with `default` value.
- Not visible in the PR: Update bitrise.yml as `android-sdk` path has changed.

Tested:
- Xcode 11.5.x, on macOS 10.15.3 (Catalina)
- Xcode 11.6.x, on macOS 10.15.6 (Catalina)
- Xcode Edge with latest Xcode and tool versions