### PR TITLE
Retry starting device when we find potential crash in the logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -253,7 +253,8 @@ waitLoop:
 			log.Warnf("Emulator log: %s", output)
 			failf("Failed to boot emulator device within %d seconds.", bootWaitTime)
 		case <-deviceCheckTicker.C:
-			serial, err := queryNewDeviceSerial(androidHome, runningDevices)
+			var err error
+			serial, err = queryNewDeviceSerial(androidHome, runningDevices)
 			if err != nil {
 				failf("Error: %s", err)
 			} else if serial != "" {

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ var (
 )
 
 const (
-	maxAttempts = 3
+	maxAttempts = 5
 )
 
 func runningDeviceInfos(androidHome string) (map[string]string, error) {

--- a/main.go
+++ b/main.go
@@ -253,7 +253,12 @@ waitLoop:
 			log.Warnf("Emulator log: %s", output)
 			failf("Failed to boot emulator device within %d seconds.", bootWaitTime)
 		case <-deviceCheckTicker.C:
-
+			serial, err := queryNewDeviceSerial(androidHome, runningDevices)
+			if err != nil {
+				failf("Error: %s", err)
+			} else if serial != "" {
+				break waitLoop
+			}
 			if strings.Contains(output.String(), faultIndicator) {
 				log.Warnf("Emulator log contains fault")
 				log.Warnf("Emulator log: %s", output)
@@ -267,12 +272,6 @@ waitLoop:
 				} else {
 					failf("Failed to boot device due to faults after %d tries", maxAttempts)
 				}
-			}
-			serial, err := queryNewDeviceSerial(androidHome, runningDevices)
-			if err != nil {
-				failf("Error: %s", err)
-			} else if serial != "" {
-				break waitLoop
 			}
 		}
 	}


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context

Sometimes when the emulator crashes during boot the step fails with timeout.

https://linear.app/bitrise/issue/MOB-191/fix-failing-ci-[steps-avd-manager]

### Changes

- Checking the output of the emulator periodically (when we poll for the serial)
- If output contains the fault indicator we kill the process and retry at most 2 times

### Investigation details

https://app.bitrise.io/build/91e6f2d7-db59-4faa-bc4e-4b288efdd8b5

### Decisions

- We match the ` BUG: ` text to decide whether the emulator crashed or not
- We try 3 times at most to start the emulator
