### PR TITLE
Enable ATD emulator tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,20 @@
 
 [![Step changelog](https://shields.io/github/v/release/bitrise-steplib/steps-avd-manager?include_prereleases&label=changelog&color=blueviolet)](https://github.com/bitrise-steplib/steps-avd-manager/releases)
 
-Create an Android emulator with the AVD Manager Step.
+Create and boot an Android emulator used for device testing
 
 <details>
 <summary>Description</summary>
 
-Test your project in an Android emulator with the AVD Manager. Once some basic inputs are set, the Step checks the requirements, downloads and installs the packages before creating and starting the emulator.
+Run instrumented and UI tests on a virtual Android device. Once some basic inputs are set, the Step checks the requirements, downloads the selected system image before creating and starting the emulator.
 
 ### Configuring the Step
 1. Add the **AVD Manager** Step to your Workflow as one of the first Steps in your Workflow.
-2. Set the **Device Profile** to create a new Android virtual device. To see the complete list of available profiles, use the `avdmanager list device` command.
+2. Set the **Device Profile** to create a new Android virtual device. To see the complete list of available profiles, use the `avdmanager list device` command and use the `id` value for this input.
 3. Set the **Android API Level**. The new virtual device will run with the specified Android version.
 4. Select an **OS Tag** to have the required toolset on the new virtual device.
+
+Some system images are pre-installed on the virtual machines. In this case the step won't have to spend time downloading the requested image. To check the list of pre-installed images for each stack, visit the [system reports](https://github.com/bitrise-io/bitrise.io/tree/master/system_reports)
 
 ### Troubleshooting
 The emulator needs some time to boot up. The earlier you place the Step in your Workflow, the more tasks, such as cloning or caching, you can complete in your Workflow before the emulator starts working.
@@ -42,7 +44,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
-| `profile` | Set the device profile to create the new AVD. This profile contains all the parameters of the devices. To see the complete list of available profiles please use the `avdmanager list device` command. | required | `pixel` |
+| `profile` | Set the device profile to create the new virtual device. This profile contains all the parameters of the devices. To see the complete list of available profiles use the `avdmanager list device` command locally and use the `id` value for this input. | required | `pixel` |
 | `api_level` | The device will run with the specified version of android. | required | `26` |
 | `tag` | Select OS tag to have the required toolset on the device. | required | `google_apis` |
 | `abi` | Select which ABI to use running the emulator. Availability depends on API level. Please use `sdkmanager --list` command to see the available ABIs. | required | `x86` |

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2,7 +2,7 @@ format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
-  generate-readme:
+  generate_readme:
     steps:
     - git::https://github.com/bitrise-steplib/steps-readme-generator.git@main: { }
 

--- a/main.go
+++ b/main.go
@@ -175,7 +175,7 @@ func main() {
 
 		{
 			"Updating system-image packages",
-			command.New(sdkManagerPath, "--verbose", pkg).
+			command.New(sdkManagerPath, "--verbose", "--channel="+cfg.EmulatorChannel, pkg).
 				SetStdin(strings.NewReader(yes)), // hitting yes in case it waits for accepting license
 		},
 

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ type config struct {
 	AndroidHome       string `env:"ANDROID_HOME"`
 	AndroidSDKRoot    string `env:"ANDROID_SDK_ROOT"`
 	APILevel          int    `env:"api_level,required"`
-	Tag               string `env:"tag,opt[google_apis,google_apis_playstore,aosp-atd,android-wear,android-tv,default]"`
+	Tag               string `env:"tag,opt[google_apis,google_apis_playstore,aosp_atd,android-wear,android-tv,default]"`
 	DeviceProfile     string `env:"profile,required"`
 	CreateCommandArgs string `env:"create_command_flags"`
 	StartCommandArgs  string `env:"start_command_flags"`

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ type config struct {
 	AndroidHome       string `env:"ANDROID_HOME"`
 	AndroidSDKRoot    string `env:"ANDROID_SDK_ROOT"`
 	APILevel          int    `env:"api_level,required"`
-	Tag               string `env:"tag,opt[google_apis,google_apis_playstore,aosp_atd,android-wear,android-tv,default]"`
+	Tag               string `env:"tag,opt[google_apis,google_apis_playstore,aosp_atd,google_atd,android-wear,android-tv,default]"`
 	DeviceProfile     string `env:"profile,required"`
 	CreateCommandArgs string `env:"create_command_flags"`
 	StartCommandArgs  string `env:"start_command_flags"`

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ type config struct {
 	AndroidHome       string `env:"ANDROID_HOME"`
 	AndroidSDKRoot    string `env:"ANDROID_SDK_ROOT"`
 	APILevel          int    `env:"api_level,required"`
-	Tag               string `env:"tag,opt[google_apis,google_apis_playstore,android-wear,android-tv,default]"`
+	Tag               string `env:"tag,opt[google_apis,google_apis_playstore,aosp-atd,android-wear,android-tv,default]"`
 	DeviceProfile     string `env:"profile,required"`
 	CreateCommandArgs string `env:"create_command_flags"`
 	StartCommandArgs  string `env:"start_command_flags"`

--- a/step.yml
+++ b/step.yml
@@ -9,7 +9,7 @@ description: |-
   2. Set the **Device Profile** to create a new Android virtual device. To see the complete list of available profiles, use the `avdmanager list device` command and use the `id` value for this input.
   3. Set the **Android API Level**. The new virtual device will run with the specified Android version.
   4. Select an **OS Tag** to have the required toolset on the new virtual device.
-  
+
   Some system images are pre-installed on the virtual machines. In this case the step won't have to spend time downloading the requested image. To check the list of pre-installed images for each stack, visit the [system reports](https://github.com/bitrise-io/bitrise.io/tree/master/system_reports)
 
   ### Troubleshooting

--- a/step.yml
+++ b/step.yml
@@ -10,7 +10,7 @@ description: |-
   3. Set the **Android API Level**. The new virtual device will run with the specified Android version.
   4. Select an **OS Tag** to have the required toolset on the new virtual device.
 
-  Some system images are pre-installed on the virtual machines. In this case the step won't have to spend time downloading the requested image. To check the list of pre-installed images for each stack, visit the [system reports](https://github.com/bitrise-io/bitrise.io/tree/master/system_reports)
+  Some system images are pre-installed on the virtual machines. In this case the step won't have to spend time downloading the requested image. To check the list of pre-installed images for each stack, visit the [system reports](https://github.com/bitrise-io/bitrise.io/tree/master/system_reports).
 
   ### Troubleshooting
   The emulator needs some time to boot up. The earlier you place the Step in your Workflow, the more tasks, such as cloning or caching, you can complete in your Workflow before the emulator starts working.

--- a/step.yml
+++ b/step.yml
@@ -63,6 +63,7 @@ inputs:
     - google_apis
     - google_apis_playstore
     - aosp_atd
+    - google_atd
     - android-wear
     - android-tv
     - default

--- a/step.yml
+++ b/step.yml
@@ -1,14 +1,16 @@
 title: AVD Manager
 summary: |-
-  Create an Android emulator with the AVD Manager Step.
+  Create and boot an Android emulator used for device testing
 description: |-
-  Test your project in an Android emulator with the AVD Manager. Once some basic inputs are set, the Step checks the requirements, downloads and installs the packages before creating and starting the emulator.
+  Run instrumented and UI tests on a virtual Android device. Once some basic inputs are set, the Step checks the requirements, downloads the selected system image before creating and starting the emulator.
 
   ### Configuring the Step
   1. Add the **AVD Manager** Step to your Workflow as one of the first Steps in your Workflow.
-  2. Set the **Device Profile** to create a new Android virtual device. To see the complete list of available profiles, use the `avdmanager list device` command.
+  2. Set the **Device Profile** to create a new Android virtual device. To see the complete list of available profiles, use the `avdmanager list device` command and use the `id` value for this input.
   3. Set the **Android API Level**. The new virtual device will run with the specified Android version.
   4. Select an **OS Tag** to have the required toolset on the new virtual device.
+  
+  Some system images are pre-installed on the virtual machines. In this case the step won't have to spend time downloading the requested image. To check the list of pre-installed images for each stack, visit the [system reports](https://github.com/bitrise-io/bitrise.io/tree/master/system_reports)
 
   ### Troubleshooting
   The emulator needs some time to boot up. The earlier you place the Step in your Workflow, the more tasks, such as cloning or caching, you can complete in your Workflow before the emulator starts working.
@@ -25,8 +27,6 @@ description: |-
 website: https://github.com/bitrise-steplib/steps-avd-manager
 source_code_url: https://github.com/bitrise-steplib/steps-avd-manager
 support_url: https://github.com/bitrise-steplib/steps-avd-manager/issues
-host_os_tags:
-- osx-10.10
 
 type_tags:
 - utility
@@ -38,13 +38,12 @@ is_skippable: false
 toolkit:
   go:
     package_name: github.com/bitrise-steplib/steps-avd-manager
-run_if: ""
+
 inputs:
 - profile: pixel
   opts:
     title: Device Profile
-    summary: Set the device profile to create the new AVD. This profile contains all the parameters of the devices. To see the complete list of available profiles please use the `avdmanager list device` command.
-    description: Set the device profile to create the new AVD. This profile contains all the parameters of the devices. To see the complete list of available profiles please use the `avdmanager list device` command.
+    description: Set the device profile to create the new virtual device. This profile contains all the parameters of the devices. To see the complete list of available profiles use the `avdmanager list device` command locally and use the `id` value for this input.
     is_required: true
 - api_level: 26
   opts:
@@ -62,8 +61,8 @@ inputs:
     value_options:
     - google_apis
     - google_apis_playstore
-    - aosp_atd
     - google_atd
+    - aosp_atd
     - android-wear
     - android-tv
     - default

--- a/step.yml
+++ b/step.yml
@@ -62,6 +62,7 @@ inputs:
     value_options:
     - google_apis
     - google_apis_playstore
+    - aosp_atd
     - android-wear
     - android-tv
     - default


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

Enable creating ATD emulator images. More info about ATD:

https://android-developers.googleblog.com/2021/10/whats-new-in-scalable-automated-testing.html
https://developer.android.com/studio/preview/features#dolphin-testing

### Changes

Adds new options to the `tag` step input: `aosp_atd` and `google_atd`. These are passed on to the `sdkmanager` call.

### Investigation details

The ATD variants are not published for every CPU architecture and API version, and `--channel=3` is also required to install these images. At the moment these are the valid step input combinations to install an ATD image:

```yml
avd-manager:
  inputs:
  - tag: google_apis
  - api_level: 30
  - abi: x86
  - emulator_channel: 3
```

```yml
avd-manager:
  inputs:
  - tag: google_apis
  - api_level: 31
  - abi: x86_64
  - emulator_channel: 3
```


```yml
avd-manager:
  inputs:
  - tag: google_apis
  - api_level: 32
  - abi: x86_64
  - emulator_channel: 3
```

### Decisions

<!-- Please list decisions that were made for this change. -->
