### PR TITLE
Improve description of device profile input

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Run instrumented and UI tests on a virtual Android device. Once some basic input
 3. Set the **Android API Level**. The new virtual device will run with the specified Android version.
 4. Select an **OS Tag** to have the required toolset on the new virtual device.
 
-Some system images are pre-installed on the virtual machines. In this case the step won't have to spend time downloading the requested image. To check the list of pre-installed images for each stack, visit the [system reports](https://github.com/bitrise-io/bitrise.io/tree/master/system_reports)
+Some system images are pre-installed on the virtual machines. In this case the step won't have to spend time downloading the requested image. To check the list of pre-installed images for each stack, visit the [system reports](https://github.com/bitrise-io/bitrise.io/tree/master/system_reports).
 
 ### Troubleshooting
 The emulator needs some time to boot up. The earlier you place the Step in your Workflow, the more tasks, such as cloning or caching, you can complete in your Workflow before the emulator starts working.
@@ -44,7 +44,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
-| `profile` | Set the device profile to create the new virtual device. This profile contains all the parameters of the devices. To see the complete list of available profiles use the `avdmanager list device` command locally and use the `id` value for this input. | required | `pixel` |
+| `profile` | The profile contains parameters of the device, such as screen size and resolution.  To see the complete list of available profiles use the `avdmanager list device` command locally and use the `id` value for this input.  | required | `pixel` |
 | `api_level` | The device will run with the specified version of android. | required | `26` |
 | `tag` | Select OS tag to have the required toolset on the device. | required | `google_apis` |
 | `abi` | Select which ABI to use running the emulator. Availability depends on API level. Please use `sdkmanager --list` command to see the available ABIs. | required | `x86` |

--- a/step.yml
+++ b/step.yml
@@ -42,9 +42,12 @@ toolkit:
 inputs:
 - profile: pixel
   opts:
-    title: Device Profile
-    summary: Set the device profile to create the new AVD.
-    description: This profile contains all the parameters of the devices. To see the complete list of available profiles use the `avdmanager list device` command locally and use the `id` value for this input.
+    title: Device Profile ID
+    summary: Device profile to use when creating the virtual device.
+    description: |
+      The profile contains parameters of the device, such as screen size and resolution.
+      
+      To see the complete list of available profiles use the `avdmanager list device` command locally and use the `id` value for this input.
     is_required: true
 - api_level: 26
   opts:

--- a/step.yml
+++ b/step.yml
@@ -46,7 +46,7 @@ inputs:
     summary: Device profile to use when creating the virtual device.
     description: |
       The profile contains parameters of the device, such as screen size and resolution.
-      
+
       To see the complete list of available profiles use the `avdmanager list device` command locally and use the `id` value for this input.
     is_required: true
 - api_level: 26


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Running `avdmanager list device` outputs both the device ID and name and it's not clear which one to use in the step input.

```
---------
id: 23 or "pixel_4"
    Name: Pixel 4
    OEM : Google
---------
id: 24 or "pixel_4_xl"
    Name: Pixel 4 XL
    OEM : Google
---------
```

### Changes

Clarify this in the `step.yml`

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
