### PR TITLE
Disable animations by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | `api_level` | The device will run with the specified system image version. | required | `26` |
 | `tag` | Select OS tag to have the required toolset on the device. | required | `google_apis` |
 | `abi` | Select which ABI to use running the emulator. Availability depends on API level. Please use `sdkmanager --list` command to see the available ABIs. | required | `x86` |
+| `disable_animations` | Disable animations on the emulator in order to make tests faster and more stable.  Animations can be enabled/disabled from the test code too, so if your tests do need animations, set this step input to `no` and control the settings yourself. | required | `yes` |
 | `emulator_id` | Set the device's ID. (This will be the name under $HOME/.android/avd/) | required | `emulator` |
 | `create_command_flags` | Flags used when running the command to create the emulator. |  | `--sdcard 2048M` |
 | `start_command_flags` | Flags used when running the command to start the emulator. |  | `-camera-back none -camera-front none` |

--- a/adb/adb.go
+++ b/adb/adb.go
@@ -100,3 +100,46 @@ func (a *ADB) FindNewDevice(previousDeviceState Devices) (string, error) {
 
 	return "", nil
 }
+
+func (a *ADB) DisableAnimations(serial string) error {
+	a.logger.Println()
+	a.logger.Infof("Disabling animations for %s", serial)
+
+	adbPath := filepath.Join(a.androidHome, "platform-tools", "adb")
+
+	cmd := a.cmdFactory.Create(
+		adbPath,
+		[]string{"-s", serial, "shell", "settings", "put", "global", "window_animation_scale", "0"},
+		nil,
+	)
+	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		a.logger.Warnf(out)
+		a.logger.Warnf("adb window_animation_scal=0: %s", err)
+	}
+
+	cmd = a.cmdFactory.Create(
+		adbPath,
+		[]string{"-s", serial, "shell", "settings", "put", "global", "transition_animation_scale", "0"},
+		nil,
+	)
+	out, err = cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		a.logger.Warnf(out)
+		a.logger.Warnf("adb transition_animation_scale=0: %s", err)
+	}
+
+	cmd = a.cmdFactory.Create(
+		adbPath,
+		[]string{"-s", serial, "shell", "settings", "put", "global", "animator_duration_scale", "0"},
+		nil,
+	)
+	out, err = cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		a.logger.Warnf(out)
+		a.logger.Warnf("adb animator_duration_scale=0: %s", err)
+	}
+
+	a.logger.Println()
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type config struct {
 	APILevel            int    `env:"api_level,required"`
 	Tag                 string `env:"tag,opt[google_apis,google_apis_playstore,aosp_atd,google_atd,android-wear,android-tv,default]"`
 	DeviceProfile       string `env:"profile,required"`
+	DisableAnimations   bool   `env:"disable_animations,opt[yes,no]"`
 	CreateCommandArgs   string `env:"create_command_flags"`
 	StartCommandArgs    string `env:"start_command_flags"`
 	ID                  string `env:"emulator_id,required"`
@@ -207,6 +208,10 @@ func main() {
 	args = append(args, startCustomFlags...)
 
 	serial := startEmulator(adbClient, emulatorPath, args, androidHome, runningDevicesBeforeBoot, 1)
+
+	if cfg.DisableAnimations {
+		adbClient.DisableAnimations(serial)
+	}
 
 	if err := tools.ExportEnvironmentWithEnvman("BITRISE_EMULATOR_SERIAL", serial); err != nil {
 		log.Warnf("Failed to export environment (BITRISE_EMULATOR_SERIAL), error: %s", err)

--- a/main.go
+++ b/main.go
@@ -210,7 +210,10 @@ func main() {
 	serial := startEmulator(adbClient, emulatorPath, args, androidHome, runningDevicesBeforeBoot, 1)
 
 	if cfg.DisableAnimations {
-		adbClient.DisableAnimations(serial)
+		err = adbClient.DisableAnimations(serial)
+		if err != nil {
+			failf("Failed to disable animations: %s", err)
+		}
 	}
 
 	if err := tools.ExportEnvironmentWithEnvman("BITRISE_EMULATOR_SERIAL", serial); err != nil {

--- a/step.yml
+++ b/step.yml
@@ -85,6 +85,19 @@ inputs:
     - armeabi-v7a
     - arm64-v8a
     - mips
+- disable_animations: "yes"
+  opts:
+    category: Advanced
+    title: Disable animations
+    summary: Disable animations on the emulator in order to make tests faster and more stable.
+    description: |-
+      Disable animations on the emulator in order to make tests faster and more stable.
+
+      Animations can be enabled/disabled from the test code too, so if your tests do need animations, set this step input to `no` and control the settings yourself.
+    is_required: true
+    value_options:
+    - "yes"
+    - "no"
 - emulator_id: emulator
   opts:
     category: Advanced


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Disabling OS animations for UI testing [is a common practice](https://developer.android.com/reference/tools/gradle-api/7.4/com/android/build/api/dsl/TestOptions#animationsDisabled()) and improves both performance and stability: https://developer.android.com/training/testing/espresso/setup#set-up-environment

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

Errors are treated as warnings and let the step continue. It's not a critical feature of the step, just an optimization.
