### PR TITLE
chore: migrate sliceutil v1 to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ By default, the Step waits for the emulator to boot up and disables system anima
 
 ## 🧩 Get started
 
-Add this step directly to your workflow in the [Bitrise Workflow Editor](https://devcenter.bitrise.io/steps-and-workflows/steps-and-workflows-index/).
+Add this step directly to your workflow in the [Bitrise Workflow Editor](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/steps/adding-steps-to-a-workflow.html).
 
 You can also run this step directly with [Bitrise CLI](https://github.com/bitrise-io/bitrise).
 
@@ -69,9 +69,8 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 We welcome [pull requests](https://github.com/bitrise-steplib/steps-avd-manager/pulls) and [issues](https://github.com/bitrise-steplib/steps-avd-manager/issues) against this repository.
 
-For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://devcenter.bitrise.io/bitrise-cli/run-your-first-build/).
+For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://docs.bitrise.io/en/bitrise-ci/bitrise-cli/running-your-first-local-build-with-the-cli.html).
 
 Learn more about developing steps:
 
-- [Create your own step](https://devcenter.bitrise.io/contributors/create-your-own-step/)
-- [Testing your Step](https://devcenter.bitrise.io/contributors/testing-and-versioning-your-steps/)
+- [Create your own step](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/developing-your-own-bitrise-step/developing-a-new-step.html)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 	"github.com/bitrise-io/go-steputils/tools"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/log"
-	"github.com/bitrise-io/go-utils/sliceutil"
+
 	v2command "github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/env"
 	v2log "github.com/bitrise-io/go-utils/v2/log"
@@ -203,7 +204,7 @@ func main() {
 		"-no-snapshot",
 		"-wipe-data",
 	}
-	if !sliceutil.IsStringInSlice("-gpu", startCustomFlags) {
+	if !slices.Contains(startCustomFlags, "-gpu") {
 		args = append(args, []string{"-gpu", "auto"}...)
 	}
 	if cfg.IsHeadlessMode {


### PR DESCRIPTION
Replace `github.com/bitrise-io/go-utils/sliceutil` (v1) usages:
- `IsStringInSlice` → `slices.Contains` (stdlib)
- `IndexOfStringInSlice` → `slices.Index` (stdlib)