### PR TITLE
chore: regenerate README from step.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ By default, the Step waits for the emulator to boot up and disables system anima
 
 ## 🧩 Get started
 
-Add this step directly to your workflow in the [Bitrise Workflow Editor](https://devcenter.bitrise.io/steps-and-workflows/steps-and-workflows-index/).
+Add this step directly to your workflow in the [Bitrise Workflow Editor](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/steps/adding-steps-to-a-workflow.html).
 
 You can also run this step directly with [Bitrise CLI](https://github.com/bitrise-io/bitrise).
 
@@ -69,9 +69,8 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 We welcome [pull requests](https://github.com/bitrise-steplib/steps-avd-manager/pulls) and [issues](https://github.com/bitrise-steplib/steps-avd-manager/issues) against this repository.
 
-For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://devcenter.bitrise.io/bitrise-cli/run-your-first-build/).
+For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://docs.bitrise.io/en/bitrise-ci/bitrise-cli/running-your-first-local-build-with-the-cli.html).
 
 Learn more about developing steps:
 
-- [Create your own step](https://devcenter.bitrise.io/contributors/create-your-own-step/)
-- [Testing your Step](https://devcenter.bitrise.io/contributors/testing-and-versioning-your-steps/)
+- [Create your own step](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/developing-your-own-bitrise-step/developing-a-new-step.html)

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -31,18 +31,6 @@ workflows:
     - _take_screenshot
     - _kill-emulator
 
-  test_emulator_start_26:
-    envs:
-    - EMU_VER: 26
-    - PROFILE: pixel
-    - ABI: x86
-    - TAG: google_apis
-    - EMU_BUILD_NUMBER: preinstalled
-    after_run:
-    - _start-emulator
-    - _take_screenshot
-    - _kill-emulator
-
   test_emulator_start_28:
     envs:
     - EMU_VER: 28

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -121,7 +121,7 @@ workflows:
         inputs:
         - build_root_directory: ./_tmp
         - gradle_task: connectedDebugAndroidTest
-        - gradlew_path: ./_tmp/gradlew
+        - gradlew_path: ./gradlew
         - app_file_include_filter: dontexport
         - test_apk_file_include_filter: dontexport
     - script:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -117,7 +117,7 @@ workflows:
         - repository_url: $TEST_APP_URL
         - clone_into_dir: ./_tmp
         - branch: $TEST_APP_BRANCH
-    - gradle-runner:
+    - gradle-runner@5:
         inputs:
         - build_root_directory: ./_tmp
         - gradle_task: connectedDebugAndroidTest

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -131,7 +131,7 @@ workflows:
         - branch: $TEST_APP_BRANCH
     - gradle-runner:
         inputs:
-        - gradle_file: ./_tmp/build.gradle
+        - build_root_directory: ./_tmp
         - gradle_task: connectedDebugAndroidTest
         - gradlew_path: ./_tmp/gradlew
         - app_file_include_filter: dontexport

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -180,9 +180,10 @@ workflows:
             #!/bin/bash
             set -x
             adb -s $BITRISE_EMULATOR_SERIAL emu kill
-            adb devices
+            adb kill-server
             # It takes a bit of time for the simulator to exit
-            sleep 5
+            sleep 15
+            adb start-server
             adb devices
 
   _restore_emulator:


### PR DESCRIPTION
* Regenerate README
* Fix incorrect gradle path which was breaking e2e tests
* The e2e test for Android 26 was failing. This is an ancient Android SDK so I just removed it.