### PR TITLE
Migrate to shared steps-check workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,14 +1,17 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
+include:
+- repository: steps-check
+  branch: master
+  path: steps.bitrise.yml
+
 workflows:
+  # check: included from steps-check/steps.bitrise.yml
+
   generate_readme:
     steps:
-    - git::https://github.com/bitrise-steplib/steps-readme-generator.git@main: { }
-
-  check:
-    steps:
-    - git::https://github.com/bitrise-steplib/steps-check.git: { }
+    - git::https://github.com/bitrise-steplib/steps-readme-generator.git@main: {}
 
   e2e:
     steps:
@@ -25,4 +28,4 @@ workflows:
         inputs:
         - profile: pixel_2
         - api_level: 30
-    - wait-for-android-emulator: { }
+    - wait-for-android-emulator: {}

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -13,7 +13,7 @@ workflows:
     - PROFILE: pixel
     - ABI: x86_64
     - TAG: google_apis
-    - EMU_BUILD_NUMBER: 12325540  # 35.1.21
+    - EMU_BUILD_NUMBER: 12325540 # 35.1.21
     after_run:
     - _start-emulator
     - _take_screenshot
@@ -102,7 +102,7 @@ workflows:
             else
               exit 1
             fi
-    - wait-for-android-emulator: { }
+    - wait-for-android-emulator: {}
 
   _run_ui_test_and_take_screenshot:
     steps:

--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func main() {
 	}
 	args = append(args, startCustomFlags...)
 
-	serial := startEmulator(adbClient, emulatorPath, args, cfg.AndroidHome, runningDevicesBeforeBoot, 1)
+	serial := startEmulator(adbClient, emulatorPath, args, runningDevicesBeforeBoot, 1)
 
 	if cfg.DisableAnimations {
 		// We need to wait for the device to boot before we can disable animations
@@ -239,7 +239,7 @@ func main() {
 	log.Printf("$BITRISE_EMULATOR_SERIAL=%s", serial)
 }
 
-func startEmulator(adbClient adb.ADB, emulatorPath string, args []string, androidHome string, runningDevices map[string]string, attempt int) string {
+func startEmulator(adbClient adb.ADB, emulatorPath string, args []string, runningDevices map[string]string, attempt int) string {
 	var output bytes.Buffer
 	deviceStartCmd := command.New(emulatorPath, args...).SetStdout(&output).SetStderr(&output)
 
@@ -311,7 +311,7 @@ waitLoop:
 	timeoutTimer.Stop()
 	deviceCheckTicker.Stop()
 	if retry {
-		return startEmulator(adbClient, emulatorPath, args, androidHome, runningDevices, attempt+1)
+		return startEmulator(adbClient, emulatorPath, args, runningDevices, attempt+1)
 	}
 	return serial
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

No version update required (CI config only)

### Context

A new shared `check` workflow is now available in `steps-check`, which uses a stricter YAML formatter and a more up-to-date `golangci-lint` version. This PR adapts the step to use the shared workflow and fixes the issues caught by the new checks.

### Changes

- Include the shared `check` workflow from `steps-check` via `include:` directive, replacing the inline step reference
- Fix YAML formatting: `{ }` → `{}` and inline comment spacing
- Remove unused `androidHome` parameter from `startEmulator` to satisfy updated golangci-lint

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->